### PR TITLE
Improved exception handling to avoid deadlock situation

### DIFF
--- a/commons-lib/src/main/java/org/opencb/commons/run/ParallelTaskRunner.java
+++ b/commons-lib/src/main/java/org/opencb/commons/run/ParallelTaskRunner.java
@@ -276,10 +276,10 @@ public class ParallelTaskRunner<I, O> {
 		for (int i = 0; i < fList.size(); i++) {
 			Future f = fList.get(i);
 			if(f.isCancelled()){
-				this.futureTasks.remove(i);
+				this.futureTasks.remove(f);
 			} else if(f.isDone()){
+				this.futureTasks.remove(f);
 				f.get(); // check for exceptions
-				this.futureTasks.remove(i);
 			}
 		}
 	}


### PR DESCRIPTION
Issue: Failed jobs don't read from queues and others wait unlimited time to put next object into queue.
Solution: Offer queues an objects with a time and repeat limit. Check for finished / failed jobs and "kill" all jobs on failure for clean shutdown.