### PR TITLE
datastore: Add WriteConcern and ReadPreference per Collection

### DIFF
--- a/commons-datastore/commons-datastore-mongodb/src/main/java/org/opencb/commons/datastore/mongodb/MongoDBCollection.java
+++ b/commons-datastore/commons-datastore-mongodb/src/main/java/org/opencb/commons/datastore/mongodb/MongoDBCollection.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.mongodb.MongoExecutionTimeoutException;
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.FindIterable;
@@ -561,4 +563,15 @@ public class MongoDBCollection {
     private String getFullName() {
         return dbCollection.getNamespace().getFullName();
     }
+
+    public MongoDBCollection withWriteConcern(WriteConcern writeConcern) {
+        dbCollection = dbCollection.withWriteConcern(writeConcern);
+        return this;
+    }
+
+    public MongoDBCollection withReadPreference(ReadPreference readPreference) {
+        dbCollection = dbCollection.withReadPreference(readPreference);
+        return this;
+    }
+
 }

--- a/commons-datastore/commons-datastore-mongodb/src/main/java/org/opencb/commons/datastore/mongodb/MongoDataStore.java
+++ b/commons-datastore/commons-datastore-mongodb/src/main/java/org/opencb/commons/datastore/mongodb/MongoDataStore.java
@@ -17,11 +17,14 @@
 package org.opencb.commons.datastore.mongodb;
 
 import com.mongodb.MongoClient;
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
 import com.mongodb.client.MongoDatabase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.function.Consumer;
 
 /**
  * Created by imedina on 22/03/14.
@@ -35,8 +38,6 @@ import java.util.*;
  */
 
 public class MongoDataStore {
-
-    private Map<String, MongoDBCollection> mongoDBCollections = new HashMap<>();
 
     private MongoClient mongoClient;
     private MongoDatabase db;
@@ -58,12 +59,19 @@ public class MongoDataStore {
 
 
     public MongoDBCollection getCollection(String collection) {
-        if (!mongoDBCollections.containsKey(collection)) {
-            MongoDBCollection mongoDBCollection = new MongoDBCollection(db.getCollection(collection));
-            mongoDBCollections.put(collection, mongoDBCollection);
-            logger.debug("MongoDataStore: new MongoDB collection '{}' created", collection);
+        return getCollection(collection, null, null);
+    }
+
+    public MongoDBCollection getCollection(String collection, WriteConcern writeConcern, ReadPreference readPreference) {
+        MongoDBCollection mongoDBCollection = new MongoDBCollection(db.getCollection(collection));
+        if (writeConcern != null) {
+            mongoDBCollection.withWriteConcern(writeConcern);
         }
-        return mongoDBCollections.get(collection);
+        if (readPreference != null) {
+            mongoDBCollection.withReadPreference(readPreference);
+        }
+        logger.debug("MongoDataStore: new MongoDB collection '{}' created", collection);
+        return mongoDBCollection;
     }
 
     public MongoDBCollection createCollection(String collectionName) {
@@ -74,10 +82,11 @@ public class MongoDataStore {
     }
 
     public void dropCollection(String collectionName) {
-        if (Arrays.asList(db.listCollectionNames()).contains(collectionName)) {
-            db.getCollection(collectionName).drop();
-            mongoDBCollections.remove(collectionName);
-        }
+        db.listCollectionNames().forEach((Consumer<String>) s -> {
+            if (s.equals(collectionName)) {
+                db.getCollection(collectionName).drop();
+            }
+        });
     }
 
     public List<String> getCollectionNames() {
@@ -110,8 +119,9 @@ public class MongoDataStore {
      * GETTERS, NO SETTERS ARE AVAILABLE TO MAKE THIS CLASS IMMUTABLE
      */
 
+    @Deprecated
     public Map<String, MongoDBCollection> getMongoDBCollections() {
-        return mongoDBCollections;
+        return Collections.emptyMap();
     }
 
     public MongoDatabase getDb() {


### PR DESCRIPTION
Add methods to configure WriteConcern and ReadPreference per collection.

Remove collections map in MongoDataStore since create new MongoDBCollections
is a light operation.