### PR TITLE
Extend finditerator and add numMatches

### DIFF
--- a/commons-datastore/commons-datastore-mongodb/src/main/java/org/opencb/commons/datastore/mongodb/MongoDBCollection.java
+++ b/commons-datastore/commons-datastore-mongodb/src/main/java/org/opencb/commons/datastore/mongodb/MongoDBCollection.java
@@ -234,7 +234,7 @@ public class MongoDBCollection {
                 try {
                     queryResultWriter.open();
                     while (cursor.hasNext()) {
-                        queryResultWriter.write(findIterable.next());
+                        queryResultWriter.write(cursor.next());
                     }
                     queryResultWriter.close();
                 } catch (IOException e) {

--- a/commons-datastore/commons-datastore-mongodb/src/main/java/org/opencb/commons/datastore/mongodb/MongoDBCollection.java
+++ b/commons-datastore/commons-datastore-mongodb/src/main/java/org/opencb/commons/datastore/mongodb/MongoDBCollection.java
@@ -19,11 +19,13 @@ package org.opencb.commons.datastore.mongodb;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.mongodb.MongoExecutionTimeoutException;
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.mongodb.bulk.BulkWriteResult;
-import com.mongodb.client.*;
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
@@ -38,10 +40,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 
 /**
  * @author Ignacio Medina &lt;imedina@ebi.ac.uk&gt;
@@ -226,27 +224,17 @@ public class MongoDBCollection {
     private <T> DataResult<T> privateFind(ClientSession clientSession, Bson query, Bson projection, Class<T> clazz,
                                            ComplexTypeConverter<T, Document> converter, QueryOptions options) {
         long start = startQuery();
-
-        Future<Long> countFuture = null;
-        if (options.getBoolean(QueryOptions.COUNT)) {
-            ExecutorService executor = Executors.newSingleThreadExecutor();
-            countFuture = executor.submit(() -> mongoDBNativeQuery.count(clientSession, query));
-        }
-
-        /**
-         * Getting the cursor and setting the batchSize from options. Default value set to 20.
-         */
-        FindIterable<Document> findIterable = mongoDBNativeQuery.find(clientSession, query, projection, options);
+        MongoDBIterator<Document> findIterable = mongoDBNativeQuery.find(clientSession, query, projection, options);
         MongoCursor<Document> cursor = findIterable.iterator();
-
         DataResult<T> queryResult;
         List<T> list = new LinkedList<>();
+
         if (cursor != null) {
             if (queryResultWriter != null) {
                 try {
                     queryResultWriter.open();
                     while (cursor.hasNext()) {
-                        queryResultWriter.write(cursor.next());
+                        queryResultWriter.write(findIterable.next());
                     }
                     queryResultWriter.close();
                 } catch (IOException e) {
@@ -277,21 +265,13 @@ public class MongoDBCollection {
                 }
             }
 
-            if (options.getBoolean(QueryOptions.COUNT)) {
-                long numTotalResults;
-                try {
-                    numTotalResults = countFuture.get();
-                } catch (MongoExecutionTimeoutException | InterruptedException | ExecutionException e) {
-                    numTotalResults = -1;
-                }
-                queryResult = endQuery(list, numTotalResults, start);
-            } else {
-                queryResult = endQuery(list, -1, start);
-            }
+            queryResult = endQuery(list, start);
             cursor.close();
         } else {
-            queryResult = endQuery(list, -1, start);
+            queryResult = endQuery(list, start);
         }
+
+        queryResult.setNumMatches(findIterable.getNumMatches());
         return queryResult;
     }
 

--- a/commons-datastore/commons-datastore-mongodb/src/main/java/org/opencb/commons/datastore/mongodb/MongoDBIterator.java
+++ b/commons-datastore/commons-datastore-mongodb/src/main/java/org/opencb/commons/datastore/mongodb/MongoDBIterator.java
@@ -1,0 +1,39 @@
+package org.opencb.commons.datastore.mongodb;
+
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCursor;
+
+import java.util.Iterator;
+
+public class MongoDBIterator<E> implements Iterator<E> {
+
+    private FindIterable<E> iterator;
+    private long numMatches;
+
+    public MongoDBIterator(FindIterable<E> iterator, long numMatches) {
+        this.iterator = iterator;
+        this.numMatches = numMatches;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return iterator.iterator().hasNext();
+    }
+
+    @Override
+    public E next() {
+        return iterator.iterator().next();
+    }
+
+    public FindIterable<E> getIterable() {
+        return iterator;
+    }
+
+    public MongoCursor<E> iterator() {
+        return iterator.iterator();
+    }
+
+    public long getNumMatches() {
+        return numMatches;
+    }
+}

--- a/commons-datastore/commons-datastore-mongodb/src/main/java/org/opencb/commons/datastore/mongodb/MongoDBIterator.java
+++ b/commons-datastore/commons-datastore-mongodb/src/main/java/org/opencb/commons/datastore/mongodb/MongoDBIterator.java
@@ -2,10 +2,13 @@ package org.opencb.commons.datastore.mongodb;
 
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCursor;
+import org.bson.conversions.Bson;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Iterator;
 
-public class MongoDBIterator<E> implements Iterator<E> {
+public class MongoDBIterator<E> implements Iterator<E>, Closeable {
 
     private FindIterable<E> iterator;
     private long numMatches;
@@ -29,11 +32,12 @@ public class MongoDBIterator<E> implements Iterator<E> {
         return iterator;
     }
 
-    public MongoCursor<E> iterator() {
-        return iterator.iterator();
-    }
-
     public long getNumMatches() {
         return numMatches;
+    }
+
+    @Override
+    public void close() throws IOException {
+        iterator.iterator().close();
     }
 }

--- a/commons-datastore/commons-datastore-mongodb/src/main/java/org/opencb/commons/datastore/mongodb/MongoDBNativeQuery.java
+++ b/commons-datastore/commons-datastore-mongodb/src/main/java/org/opencb/commons/datastore/mongodb/MongoDBNativeQuery.java
@@ -107,7 +107,7 @@ public class MongoDBNativeQuery {
     public MongoDBIterator<Document> find(ClientSession clientSession, Bson query, Bson projection, QueryOptions options) {
 
         Future<Long> countFuture = null;
-        if (options.getBoolean(QueryOptions.COUNT)) {
+        if (options != null && options.getBoolean(QueryOptions.COUNT)) {
             ExecutorService executor = Executors.newSingleThreadExecutor();
             countFuture = executor.submit(() -> count(clientSession, query));
         }
@@ -178,7 +178,7 @@ public class MongoDBNativeQuery {
         }
 
         long numMatches = -1;
-        if (options.getBoolean(QueryOptions.COUNT)) {
+        if (options != null && options.getBoolean(QueryOptions.COUNT)) {
             try {
                 numMatches = countFuture.get();
             } catch (MongoExecutionTimeoutException | InterruptedException | ExecutionException e) {

--- a/commons-datastore/commons-datastore-mongodb/src/main/java/org/opencb/commons/datastore/mongodb/MongoPersistentCursor.java
+++ b/commons-datastore/commons-datastore-mongodb/src/main/java/org/opencb/commons/datastore/mongodb/MongoPersistentCursor.java
@@ -112,7 +112,7 @@ public class MongoPersistentCursor implements MongoCursor<Document> {
     }
 
     protected FindIterable<Document> newFindIterable(Bson query, Bson projection, QueryOptions options) {
-        return this.collection.nativeQuery().find(query, projection, options);
+        return this.collection.nativeQuery().find(query, projection, options).getIterable();
     }
 
     public Object getLastId() {


### PR DESCRIPTION
* created a new iterator that extends the existing one and includes `numMatches`
* moved the COUNT logic to `MongoDBNativeQuery` from `MongoDBCollection`
* SKIP_COUNT is removed and now has no effect. 
* The COUNT logic is correct now, and independent of SKIP and LIMIT.