### PR TITLE
TASK-5444 - Fix OpenCB repository versions to conform to XetaBase 2.0.0 version

### DIFF
--- a/commons-datastore/commons-datastore-core/pom.xml
+++ b/commons-datastore/commons-datastore-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.commons</groupId>
         <artifactId>commons-datastore</artifactId>
-        <version>4.13.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/commons-datastore/commons-datastore-mongodb/pom.xml
+++ b/commons-datastore/commons-datastore-mongodb/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.commons</groupId>
         <artifactId>commons-datastore</artifactId>
-        <version>4.13.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/commons-datastore/commons-datastore-solr/pom.xml
+++ b/commons-datastore/commons-datastore-solr/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.opencb.commons</groupId>
         <artifactId>commons-datastore</artifactId>
-        <version>4.13.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/commons-datastore/pom.xml
+++ b/commons-datastore/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.commons</groupId>
         <artifactId>commons</artifactId>
-        <version>4.13.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/commons-lib/pom.xml
+++ b/commons-lib/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.commons</groupId>
         <artifactId>commons</artifactId>
-        <version>4.13.0-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.opencb.commons</groupId>
     <artifactId>commons</artifactId>
-    <version>4.13.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>OpenCB commons project</name>


### PR DESCRIPTION
TASK-5444 - Fix OpenCB repository versions to conform to XetaBase 2.0.0 version