### PR TITLE
TASK-6255 Update Exomiser Docker image to v14.0.0

### DIFF
--- a/commons-lib/pom.xml
+++ b/commons-lib/pom.xml
@@ -68,5 +68,11 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.8.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/commons-lib/src/main/java/org/opencb/commons/utils/FileUtils.java
+++ b/commons-lib/src/main/java/org/opencb/commons/utils/FileUtils.java
@@ -18,6 +18,7 @@ package org.opencb.commons.utils;
 
 import org.apache.commons.lang3.StringUtils;
 import org.opencb.commons.exec.Command;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.nio.charset.Charset;
@@ -187,6 +188,27 @@ public class FileUtils {
 
         return new String[]{split[2], split[3]};
     }
+
+
+    public static void copyFile(File src, File dest) throws IOException {
+        try {
+            org.apache.commons.io.FileUtils.copyFile(src, dest);
+        } catch (IOException e) {
+            try {
+                if (src.length() == dest.length()) {
+                    LoggerFactory.getLogger(FileUtils.class).warn(e.getMessage());
+                    return;
+                }
+                throw e;
+            } catch (Exception e1) {
+                throw e;
+            }
+        }
+    }
+
+    //-------------------------------------------------------------------------
+    // P R I V A T E     M E T H O D S
+    //-------------------------------------------------------------------------
 
     private static String getLsOutput(Path path, boolean numericId) throws IOException {
         FileUtils.checkPath(path);


### PR DESCRIPTION
Add the method copyFile to the FileUtils that is used by the requirement to update the Exomiser Docker image to v14.0.0
[TASK-6255](https://app.clickup.com/t/8694k8pa0)
